### PR TITLE
Update github urls to correct names

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -258,7 +258,7 @@ fi
 ### Setup ###
 
 if [[ $setup == true ]]; then
-    git clone https://github.com/pepecoin/gitian.sigs.git
+    git clone https://github.com/pepecoinppc/gitian.sigs.git
     git clone https://github.com/pepecoinppc/pepecoin-detached-sigs.git
     git clone https://github.com/devrandom/gitian-builder.git
 

--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -136,8 +136,8 @@ This will create the `.sig` files that can be committed together with the `.asse
 
 ## Publish signatures
 
-Gitian signatures for each release are added to https://github.com/pepecoin/gitian.sigs.
+Gitian signatures for each release are added to https://github.com/pepecoinppc/gitian.sigs.
 
-`gitian-build.sh` will create signatures inside `gitian-output/sigs/` folder. Create a pull request to [pepecoin/gitian.sigs](https://github.com/pepecoin/gitian.sigs) to publish your signatures, the `.assert` and `.assert.sig` files.
+`gitian-build.sh` will create signatures inside `gitian-output/sigs/` folder. Create a pull request to [pepecoin/gitian.sigs](https://github.com/pepecoinppc/gitian.sigs) to publish your signatures, the `.assert` and `.assert.sig` files.
 
 **When your PR is merged, you will be recorded for all future history as a *Gitian Builder of Pepecoin Core*!**

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -31,8 +31,8 @@ If you're using the automated script (found in [contrib/gitian-build.sh](/contri
 Check out the source code in the following directory hierarchy.
 
     cd /path/to/your/toplevel/build
-    git clone https://github.com/pepecoin-core/gitian.sigs.git
-    git clone https://github.com/pepecoin-core/pepecoin-detached-sigs.git
+    git clone https://github.com/pepecoinppc/gitian.sigs.git
+    git clone https://github.com/pepecoinppc/pepecoin-detached-sigs.git
     git clone https://github.com/devrandom/gitian-builder.git
     git clone https://github.com/pepecoinppc/pepecoin.git
 


### PR DESCRIPTION
Update GitHub URLs from github.com/pepecoin/<repo_name> to github.com/pepecoinppc/<repo_name>