### PR TITLE
Add consensus param min seconds between blocks

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,6 +116,9 @@ public:
         // By default assume that the signatures in ancestors of this block are valid.
         consensus.defaultAssumeValid = uint256S("0x37981c0c48b8d48965376c8a42ece9a0838daadb93ff975cb091f57f8c2a5faa"); // genesis block
 
+        // allow blocks mined less than one second apart
+        consensus.minSecondsBetweenBlocks = 0;
+
         // AuxPoW parameters
         consensus.nAuxpowChainId = 0x003f; // 63
         consensus.fStrictChainId = true;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -72,6 +72,7 @@ struct Params {
     bool fDigishieldDifficultyCalculation;
     bool fPowAllowDigishieldMinDifficultyBlocks; // Allow minimum difficulty blocks where a retarget would normally occur
     bool fSimplifiedRewards; // Use block height derived rewards rather than previous block hash derived
+    uint32_t minSecondsBetweenBlocks;
 
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3110,6 +3110,10 @@ bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationState& sta
     if (block.GetBlockTime() > nAdjustedTime + 2 * 60 * 60)
         return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
 
+    // Check timestamp delta to previous block against consensus parameter
+    if (consensusParams.minSecondsBetweenBlocks > 0 && block.GetBlockTime() - pindexPrev->GetBlockTime() < consensusParams.minSecondsBetweenBlocks)
+        return state.Invalid(false, REJECT_INVALID, "time-too-old", "block's timestamp is too early");
+
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     // Pepecoin: Version 2 enforcement was never used


### PR DESCRIPTION
This is set to 0 by default but allows a consensus parameter to disallow blocks from validating if their mining times are too close together.

To *use* this, select a block height at which this is valid, make a new consensus param structure in `src/chainparams.cpp`, and add it to the binary tree.

Note that at least 51% of nodes (at least those which propagate newly-mined blocks to the network) will have to agree on this change for it to take effect.