### PR TITLE
Switch to auxpow at block 38k

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -123,7 +123,7 @@ public:
         consensus.nHeightEffective = 0;
         consensus.fSimplifiedRewards = true;
 
-        // Blocks 1000 - 99,999 are Digishield without AuxPoW
+        // Blocks 1000 - 37,999 are Digishield without AuxPoW
         digishieldConsensus = consensus;
         digishieldConsensus.nHeightEffective = 1000;
         digishieldConsensus.fSimplifiedRewards = true;
@@ -131,10 +131,10 @@ public:
         digishieldConsensus.nPowTargetTimespan = 60; // post-digishield: 1 minute
         digishieldConsensus.nCoinbaseMaturity = 240;
 
-        // Blocks 100,000+ are AuxPoW
+        // Blocks 38,000+ are AuxPoW
         // Some tests from Dogecoin expect non-auxpow blocks. This allows those tests to pass.
         auxpowConsensus = digishieldConsensus;
-        auxpowConsensus.nHeightEffective = 100000;
+        auxpowConsensus.nHeightEffective = 38000;
         auxpowConsensus.fAllowLegacyBlocks = false;
 
         // Assemble the binary search tree of consensus parameters
@@ -256,15 +256,15 @@ public:
         digishieldConsensus.fPowAllowMinDifficultyBlocks = false;
         digishieldConsensus.nCoinbaseMaturity = 240;
 
-        // Blocks 1250 - 99,999 are Digishield with minimum difficulty on all blocks
+        // Blocks 1250 - 37,999 are Digishield with minimum difficulty on all blocks
         minDifficultyConsensus = digishieldConsensus;
         minDifficultyConsensus.nHeightEffective = 1250;
         minDifficultyConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
         minDifficultyConsensus.fPowAllowMinDifficultyBlocks = true;
 
-        // Enable AuxPoW at 100,000
+        // Enable AuxPoW at 38,000
         auxpowConsensus = minDifficultyConsensus;
-        auxpowConsensus.nHeightEffective = 100000;
+        auxpowConsensus.nHeightEffective = 38000;
         auxpowConsensus.fPowAllowDigishieldMinDifficultyBlocks = true;
         auxpowConsensus.fAllowLegacyBlocks = false;
 

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <algorithm>
+#include <stdexcept>
 
 LockedPoolManager* LockedPoolManager::_instance = NULL;
 std::once_flag LockedPoolManager::init_flag;

--- a/src/test/pepecoin_tests.cpp
+++ b/src/test/pepecoin_tests.cpp
@@ -188,13 +188,13 @@ BOOST_AUTO_TEST_CASE(hardfork_parameters)
     BOOST_CHECK_EQUAL(digishieldParams.fAllowLegacyBlocks, true);
     BOOST_CHECK_EQUAL(digishieldParams.fDigishieldDifficultyCalculation, true);
 
-    const Consensus::Params& digishieldParamsEnd = Params().GetConsensus(99999);
+    const Consensus::Params& digishieldParamsEnd = Params().GetConsensus(37999);
     BOOST_CHECK_EQUAL(digishieldParamsEnd.nPowTargetTimespan, 60);
     BOOST_CHECK_EQUAL(digishieldParamsEnd.fAllowLegacyBlocks, true);
     BOOST_CHECK_EQUAL(digishieldParamsEnd.fDigishieldDifficultyCalculation, true);
 
-    const Consensus::Params& auxpowParams = Params().GetConsensus(100000);//PEPE TODO Magic number
-    BOOST_CHECK_EQUAL(auxpowParams.nHeightEffective, 100000);//PEPE TODO Magic number
+    const Consensus::Params& auxpowParams = Params().GetConsensus(38000);//PEPE TODO Magic number
+    BOOST_CHECK_EQUAL(auxpowParams.nHeightEffective, 38000);//PEPE TODO Magic number
     BOOST_CHECK_EQUAL(auxpowParams.nPowTargetTimespan, 60);
     BOOST_CHECK_EQUAL(auxpowParams.fAllowLegacyBlocks, false);
     BOOST_CHECK_EQUAL(auxpowParams.fDigishieldDifficultyCalculation, true);

--- a/src/version.h
+++ b/src/version.h
@@ -9,10 +9,6 @@
  * network protocol versioning
  */
 
-// XXX: Decide if this is appropriate - if we reintroduce alerts we may need
-//      to  reduce to 70012
-static const int PROTOCOL_VERSION = 70015;
-
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
 
@@ -46,5 +42,11 @@ static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 70015;
+
+//! accept merge mining before block 100k, starting with this version
+static const int AUXPOW_BEFORE_100K_VERSION = 70016;
+
+//! current protocol version
+static const int PROTOCOL_VERSION = AUXPOW_BEFORE_100K_VERSION;
 
 #endif // BITCOIN_VERSION_H


### PR DESCRIPTION
This should target a different base and, for me at least, needs #51 applied to compile. All tests pass.

If #51 is merged first, I'll rebase this one.