### PR TITLE
Reduce the amount of blockchain space recommended

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -24,7 +24,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 55;
+static const uint64_t BLOCK_CHAIN_SIZE = 3;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 2;
 /* Total required space (in GB) depending on user choice (prune, not prune) */


### PR DESCRIPTION
Currently the blockchain storage space is less than 100 MB, so recommending at least 2 GB each for blocks and chainstate gives room to grow but will require less from users.

Reported in Discord by lostinbtc.