### PR TITLE
Fixes to language picker and AuxPow starting block

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Changes:
 
 * Addresses start with `P` instead of `D`
 * BIPS features will start block 1000
-* AuxPow starts at block 100,000 (Chain ID: 63)
+* AuxPow starts at block 42,000 (Chain ID: 63)
 * GUI themed for Pepecoin
 
 ## Usage 💻

--- a/README_fa_IR.md
+++ b/README_fa_IR.md
@@ -4,7 +4,7 @@
 Pepecoin Core [PEPE, ₱]
 </h1>  
 
-انتخاب زبان: EN | [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
+انتخاب زبان: FA | [EN](./README.md) | [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [VI](./README_vi_VN.md)
 
 پپکوین یک ارز دیجیتال تمرکز شده بر انجمن است که توسط یکی از اعضای اصلی شب‌های دوجکوین از سال 2013 ایجاد شد. هدف از ایجاد آن ایجاد یک انجمن جدید و سرگرم‌کننده مانند انجمن اصلی دوجکوین بود.
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -4,7 +4,7 @@
 Pepecoin Core [PEPE, ₱]  
 </h1>
 
-Selecionar idioma: EN | [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
+Selecionar idioma: PT | [EN](./README.md) | [CN](./README_zh_CN.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
 
 Pepecoin é uma criptomoeda focada na comunidade, criada por um dos shibes originais do Dogecoin de 2013. Foi criada com um propósito, criar uma comunidade nova e divertida, assim como a comunidade original do Dogecoin.
 

--- a/README_vi_VN.md
+++ b/README_vi_VN.md
@@ -4,7 +4,7 @@
 Nhân Tố Pepecoin [PEPE, ₱]  
 </h1>
 
-Chọn ngôn ngữ: EN | [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
+Chọn ngôn ngữ: VI | [EN](./README.md)| [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md)
 
 Pepecoin là một loại tiền điện tử tập trung vào cộng đồng được tạo ra bởi một trong những người sáng tạo Dogecoin ban đầu từ năm 2013. Nó được tạo ra với một mục đích, để tạo ra một cộng đồng mới và vui vẻ giống như cộng đồng Dogecoin ban đầu.
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -4,7 +4,7 @@
 Pepecoin Core [PEPE, ₱]  
 </h1>
 
-选择语言: EN | [CN](./README_zh_CN.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
+选择语言: CN | [EN](./README.md) | [PT](./README_pt_BR.md) | [FA](./README_fa_IR.md) | [VI](./README_vi_VN.md)
 
 Pepecoin是由2013年原始Dogecoin shibes之一创建的社区关注的加密货币。它被创建出于一个目的，就是创建一个像原始Dogecoin社区一样新奇有趣的社区。
 


### PR DESCRIPTION
Fixed selection of languages, before when selected different language, it kept text as active on EN translation on all of them. Fixed also AuxPow starting block, it was set to 100,000 but it should be 42,000 as AuxPow had hard fork.