### PR TITLE
Rebrand some documentation

### DIFF
--- a/doc/build-macos.md
+++ b/doc/build-macos.md
@@ -1,11 +1,11 @@
-# Building dogecoin-qt 1.14 on MacOS #
+# Building pepecoin 1.14 on MacOS #
 
 Tested on MacOs Ventura and Sonoma on Intel (x86_64) and Apple Silicon (arm64) macs.
 
-### Clone dogecoin locally, or check it out, etc. ###
+### Clone pepecoin locally, or check it out, etc. ###
 
 ```sh
-git clone https://github.com/dogecoin/dogecoin.git
+git clone https://github.com/pepecoinppc/pepecoin.git
 ```
 
 ### Set up OSX basic build dependencies. ##
@@ -40,10 +40,10 @@ brew install autoconf automake libtool miniupnpc openssl pkg-config protobuf@21 
 brew link protobuf@21
 ```
 
-### Go back to your Dogecoin repo ###
+### Go back to your Pepecoin repo ###
 
 ```sh
-cd ~/dogecoin
+cd ~/pepecoin
 
 ./autogen.sh
 ./configure --with-gui=qt5 --with-boost=`brew --prefix boost`
@@ -61,5 +61,5 @@ Go have another beverage.
 Run it.
 
 ```sh
-/usr/local/bin/dogecoin-qt
+/usr/local/bin/pepecoin-qt
 ```

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -64,8 +64,9 @@ build process.
 
 ## Get the Source Code
 
-To build Dogecoin from source code, you'll need the source code. Either check it out via `git` or download
-a zip file. (Look at the green "<> Code" button on [the Dogecoin GitHub repository](https://github.com/dogecoin/dogecoin/)).
+To build from source code, you'll need the source code. Either check it out via
+`git` or download a zip file. (Look at the green "<> Code" button on [the
+Pepecoin GitHub repository](https://github.com/pepecoinppc/pepecoin/)).
 
 Make sure this code is available in your Ubuntu directory. If you've unzipped a single downloaded file, you may need to change
 the permissions of all extracted files with command like:
@@ -75,7 +76,7 @@ the permissions of all extracted files with command like:
 If you've downloaded via `git`, do not use `sudo`. Instead prefer something like:
 
     cd $HOME
-    git clone https://github.com/dogecoin/dogecoin.git
+    git clone https://github.com/pepecoinppc/pepecoin.git
     git checkout <branchname>
 
 ... where `<branchname>` is the name of the branch you want to build, such as
@@ -139,7 +140,7 @@ To build executables for Windows 32-bit, install the following dependencies:
 
     sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev
 
-Ensure that this toolchain can build for `posix` (else you may have compilation errors for Dogecoin's dependencies):
+Ensure that this toolchain can build for `posix` (else you may have compilation errors for Pepecoin's dependencies):
 
     sudo update-alternatives --config i686-w64-mingw32-g++
 

--- a/doc/experiments.md
+++ b/doc/experiments.md
@@ -8,7 +8,7 @@ specifically help the introduction of performance updates or other lower-level
 improvements where positive and/or negative effects may take a longer time to
 test. The PR benefits from being merged because this makes it easier for
 testers to pick and choose sets of features to experiment with in their custom
-built Dogecoin Core deployments.
+built Pepecoin Core deployments.
 
 ## Enabling experimental features
 


### PR DESCRIPTION
This doesn't touch release notes; a different strategy may be more useful there.