### PR TITLE
add Example RPC Python File

### DIFF
--- a/ex.config.json
+++ b/ex.config.json
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Example Pepecoin RPC usage
+# Save this file as pepecoin_example.py
+
+from bitcoinrpc.authproxy import AuthServiceProxy
+
+# Replace with your Pepecoin Core RPC credentials
+rpc_user = "your_rpc_username"
+rpc_password = "your_rpc_password"
+
+# Connect to local Pepecoin node
+rpc_connection = AuthServiceProxy(f"http://{rpc_user}:{rpc_password}@127.0.0.1:33873")
+
+# Get blockchain info
+info = rpc_connection.getblockchaininfo()
+print("Pepecoin blockchain info:")
+print(info)
+
+# Get wallet balance
+balance = rpc_connection.getbalance()
+print("Your wallet balance:", balance, "Ᵽ")


### PR DESCRIPTION
This PR adds a new file pepecoin_example.py which demonstrates how to connect to a local Pepecoin node via RPC using Python.

What’s included:
Example usage of bitcoinrpc.authproxy
Commands to fetch basic blockchain info
Example wallet balance check
Why this is useful:
Helps developers quickly test RPC calls against Pepecoin Core
Provides a simple starting point for integrating Pepecoin into Python-based tools
Lowers the entry barrier for new contributors who want to interact with the blockchain
Next steps:
Extend with more example RPC calls (e.g. sending transactions, creating wallets)
Consider adding similar snippets in other languages (Node.js, Go, etc.)