### PR TITLE
Increase default -datacarriersize to 1654 (1650 byte payload)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,11 +232,11 @@ jobs:
         run: ${{ matrix.postinstall }}
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: SDK cache
         if: ${{ matrix.sdk }}
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: sdk
         with:
@@ -256,7 +256,7 @@ jobs:
           tar -C depends/SDKs -xf depends/sdk-sources/${{ env.sdk-filename }}
 
       - name: Dependency cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: depends
         with:
@@ -268,7 +268,7 @@ jobs:
           make $MAKEJOBS -C depends HOST=${{ matrix.host }} ${{ matrix.dep-opts }}
 
       - name: CCache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: ccache
         with:
@@ -301,7 +301,7 @@ jobs:
         run: make -C src check-symbols
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
           name: pepecoin-${{ github.sha }}-${{ matrix.name }}
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Update system
       run: |
@@ -43,7 +43,7 @@ jobs:
         sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils --yes
 
     - name: Dependency cache
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       env:
         cache-name: depends
       with:
@@ -57,7 +57,7 @@ jobs:
         popd
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
 
@@ -68,4 +68,4 @@ jobs:
        make -j4
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,6 +12,21 @@ jobs:
     name: Check Translations
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Lint translation files
       run: python3 contrib/devtools/check-translations.py
+  subtrees:
+    name: Check Subtrees
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Install prerequisites
+      run: sudo apt update && sudo apt install -y bash git jq
+    - name: Checkout
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+    - name: Check subtree integrity
+      run: |
+        jq -r '.[] | [.name, .remote] | join(" ")' contrib/subtrees.json | xargs -n2 git remote add
+        jq -r '.[].name' contrib/subtrees.json | xargs -n1 git fetch
+        jq -r '.[].path' contrib/subtrees.json | xargs -n1 bash contrib/devtools/git-subtree-check.sh

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -481,7 +481,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-harddustlimit=<amt>", strprintf(_("Amount under which a transaction output is considered non-standard and will not be accepted or relayed, in %s (default: %s)"), CURRENCY_UNIT, FormatMoney(DEFAULT_HARD_DUST_LIMIT)));
     strUsage += HelpMessageOpt("-bytespersigop", strprintf(_("Equivalent bytes per sigop in transactions for relay and mining (default: %u)"), DEFAULT_BYTES_PER_SIGOP));
     strUsage += HelpMessageOpt("-datacarrier", strprintf(_("Relay and mine data carrier transactions (default: %u)"), DEFAULT_ACCEPT_DATACARRIER));
-    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
+    strUsage += HelpMessageOpt("-datacarriersize", strprintf(_("Maximum size of data per data carrier output we relay and mine (default: %u)"), MAX_OP_RETURN_RELAY));
     strUsage += HelpMessageOpt("-mempoolreplacement", strprintf(_("Enable transaction replacement in the memory pool (default: %u)"), DEFAULT_ENABLE_REPLACEMENT));
 
     strUsage += HelpMessageGroup(_("Block creation options:"));

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
     CScriptID(const uint160& in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83; //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY = 1654; //!< bytes (+1 for OP_RETURN, +1 for the pushdata opcode, +2 for pushdata length)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -734,12 +734,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex(std::string(1650 * 2, 'a'));
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex(std::string(1651 * 2, 'a'));
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(!IsStandardTx(t, reason));
 


### PR DESCRIPTION
Raises `MAX_OP_RETURN_RELAY` from 83 to 1654 bytes, allowing up to 1650 bytes of effective `OP_RETURN` payload per data carrier output by default.

Also clarifies the `-datacarriersize` help text to reflect that the limit applies per data carrier output.

[Per a discussion about Dogecoin](https://github.com/dogecoin/dogecoin/discussions/3829#discussioncomment-14671883), raising the `OP_RETURN` relay size limit's default could reduce overhead of protocols built on-top of Pepecoin.